### PR TITLE
A more liberal regex for getting host and port

### DIFF
--- a/tempwork/_main.js
+++ b/tempwork/_main.js
@@ -38,8 +38,9 @@ function serveStatic(request, response, localPath) {
 function handleRequest(request, response){
   var workerName;
   var proxyUrl;
-  var host = request.headers.host.match(/([-a-z\.]+):/)[1];
-  var port = request.headers.host.match(/:(\d+)/)[1];
+  var hostPieces = request.headers.host.match(/([^:]+):(\d+)/);
+  var host = hostPieces[1];
+  var port = hostPieces[2];
   console.log(request.headers.host, host, port);
 
   for (workerName in config.workers) {


### PR DESCRIPTION
Mostly about #4.  It may be _too_ liberal, though, as it permits basically everything.  But since hostnames can include non-ASCII characters, it's pretty hard to match them with a more precise regex.
